### PR TITLE
delete redundant hover text

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
               viewBox="0 0 595.28 841.89"
             >
               <defs></defs>
-              <title>20170427直播用台灣</title>
+              <title></title>
               <path
                 id="161d6372-ac8f-409c-ad51-9db7795c8614"
                 data-name="path2462"


### PR DESCRIPTION
移除 移到台灣地圖上會產生的"2017直播用台灣"字樣